### PR TITLE
Support for multi business setup

### DIFF
--- a/lib/kinde_sdk.rb
+++ b/lib/kinde_sdk.rb
@@ -36,8 +36,6 @@ module KindeSdk
       params = {
         redirect_uri: redirect_uri,
         state: SecureRandom.hex,
-        authorize_url: "#{domain}/oauth2/auth",
-        token_url: "#{domain}/oauth2/token",
         scope: @config.scope
       }.merge(**kwargs)
       return { url: @config.oauth_client(

--- a/lib/kinde_sdk.rb
+++ b/lib/kinde_sdk.rb
@@ -27,10 +27,12 @@ module KindeSdk
     # receive url for authorization in Kinde itself
     #
     # @return [Hash]
-    def auth_url(redirect_uri: @config.callback_url, **kwargs)
+    def auth_url(redirect_uri: @config.callback_url, domain: @config.domain, **kwargs)
       params = {
         redirect_uri: redirect_uri,
         state: SecureRandom.hex,
+        authorize_url: "#{domain}/oauth2/auth",
+        token_url: "#{domain}/oauth2/token",
         scope: @config.scope
       }.merge(**kwargs)
       return { url: @config.oauth_client.auth_code.authorize_url(params) } unless @config.pkce_enabled

--- a/lib/kinde_sdk/configuration.rb
+++ b/lib/kinde_sdk/configuration.rb
@@ -36,7 +36,7 @@ module KindeSdk
       yield(self) if block_given?
     end
 
-    def oauth_client
+    def oauth_client(client_id: @client_id, client_secret: @client_secret, domain: @domain, authorize_url: @authorize_url, token_url: @token_url )
       ::OAuth2::Client.new(
         client_id,
         client_secret,


### PR DESCRIPTION
update: changed logic to handle overriding of crucial values from external source. This enables the user to implement their own account pooling. And be thread safe for it

# Explain your changes

Our customers require the ability to support multiple secrets and domains. These changes were implemented to facilitate these in a thread safe manor.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
