### PR TITLE
Fix oauth2 2.0.10+ token hash incompatibility.

### DIFF
--- a/lib/kinde_sdk.rb
+++ b/lib/kinde_sdk.rb
@@ -215,7 +215,7 @@ module KindeSdk
         authorize_url: "#{domain}/oauth2/auth",
         token_url: "#{domain}/oauth2/token")
       refreshed = OAuth2::AccessToken.from_hash(oauth_client, TokenHash.normalize(hash)).refresh
-      TokenHash.for_session(TokenHash.from_access_token(refreshed))
+      TokenHash.for_refresh_response(refreshed.to_hash)
     end
 
     # init sdk api client by bearer token

--- a/lib/kinde_sdk.rb
+++ b/lib/kinde_sdk.rb
@@ -10,6 +10,7 @@ end
 require "kinde_sdk/version"
 require "kinde_sdk/configuration"
 require "kinde_sdk/logging"
+require "kinde_sdk/token_hash"
 require "kinde_sdk/client/feature_flags"
 require "kinde_sdk/client/permissions"
 require "kinde_sdk/client"
@@ -108,14 +109,7 @@ module KindeSdk
         authorize_url: "#{domain}/oauth2/auth",
         token_url: "#{domain}/oauth2/token").auth_code.get_token(code.to_s, params)
 
-      {
-        access_token: token.token,           # The access token
-        id_token: token.params['id_token'],  # The ID token from params
-        expires_at: token.expires_at,        # Optional: expiration time
-        refresh_token: token.refresh_token,   # Optional: if present
-        scope: token.params['scope'],        # The scopes requested
-        token_type: token.params['token_type'] # The token type
-      }.compact
+      TokenHash.from_access_token(token)
     end
 
     # tokens_hash #=>
@@ -128,8 +122,14 @@ module KindeSdk
     #
     # @return [KindeSdk::Client]
     def client(tokens_hash, auto_refresh_tokens = @config.auto_refresh_tokens, force_api = @config.force_api)
-      sdk_api_client = api_client(tokens_hash[:access_token] || tokens_hash["access_token"])
-      KindeSdk::Client.new(sdk_api_client, tokens_hash, auto_refresh_tokens, force_api)
+      normalized_tokens = TokenHash.normalize(tokens_hash)
+      bearer_token = normalized_tokens[:access_token]
+      if bearer_token.nil? || bearer_token.empty?
+        raise AuthenticationError, "Missing access_token in token hash"
+      end
+
+      sdk_api_client = api_client(bearer_token)
+      KindeSdk::Client.new(sdk_api_client, normalized_tokens, auto_refresh_tokens, force_api)
     end
 
     def logout_url(logout_url: @config.logout_url, domain: @config.domain)
@@ -190,11 +190,11 @@ module KindeSdk
       begin
         validate_jwt_token(hash)
         OAuth2::AccessToken.from_hash(@config.oauth_client(
-          client_id: client_id, 
+          client_id: client_id,
           client_secret: client_secret,
           domain: domain,
           authorize_url: "#{domain}/oauth2/auth",
-          token_url: "#{domain}/oauth2/token"), hash).expired?
+          token_url: "#{domain}/oauth2/token"), TokenHash.normalize(hash)).expired?
       rescue JWT::DecodeError, OAuth2::Error => e
         log_error("Error checking token expiration: #{e.message}")
         true
@@ -208,12 +208,14 @@ module KindeSdk
       audience: "#{@config.domain}/api",
       domain: @config.domain
     )
-      OAuth2::AccessToken.from_hash(@config.oauth_client(
-        client_id: client_id, 
+      oauth_client = @config.oauth_client(
+        client_id: client_id,
         client_secret: client_secret,
         domain: domain,
         authorize_url: "#{domain}/oauth2/auth",
-        token_url: "#{domain}/oauth2/token"), hash).refresh.to_hash
+        token_url: "#{domain}/oauth2/token")
+      refreshed = OAuth2::AccessToken.from_hash(oauth_client, TokenHash.normalize(hash)).refresh
+      TokenHash.for_session(TokenHash.from_access_token(refreshed))
     end
 
     # init sdk api client by bearer token

--- a/lib/kinde_sdk/token_hash.rb
+++ b/lib/kinde_sdk/token_hash.rb
@@ -1,20 +1,20 @@
 module KindeSdk
-  # Normalizes token hashes so the SDK does not depend on oauth2's #to_hash key format.
+  # Normalizes token hash key types for oauth2 round-trips and SDK consumers.
   # Accepts string or symbol keys on input; internal storage uses symbol keys.
   module TokenHash
-    KEYS = %i[access_token refresh_token expires_at id_token scope token_type expires_in].freeze
+    PUBLIC_KEYS = %i[
+      access_token refresh_token expires_at id_token scope token_type expires_in
+    ].freeze
 
     module_function
 
+    # Symbolize keys while preserving the full oauth2 hash contract.
     def normalize(raw)
       return {} if raw.nil?
       return {} if raw.respond_to?(:empty?) && raw.empty?
 
       raw.each_with_object({}) do |(key, value), memo|
-        sym_key = key.to_sym
-        next unless KEYS.include?(sym_key)
-
-        memo[sym_key] = value
+        memo[key.to_sym] = value
       end.tap do |hash|
         hash[:access_token] = hash[:access_token].to_s if hash[:access_token]
       end
@@ -24,22 +24,30 @@ module KindeSdk
       normalize(raw)[:access_token]
     end
 
+    # Reduced shape for documented public SDK responses (e.g. fetch_tokens).
+    def public_tokens(raw)
+      normalize(raw).slice(*PUBLIC_KEYS).compact
+    end
+
     def from_access_token(token)
-      normalize(
-        {
-          access_token: token.token,
-          refresh_token: token.refresh_token,
-          expires_at: token.expires_at,
-          id_token: token_param(token, "id_token"),
-          scope: token_param(token, "scope"),
-          token_type: token_param(token, "token_type"),
-          expires_in: token_param(token, "expires_in")
-        }.compact
+      public_tokens(
+        access_token: token.token,
+        refresh_token: token.refresh_token,
+        expires_at: token.expires_at,
+        id_token: token_param(token, "id_token"),
+        scope: token_param(token, "scope"),
+        token_type: token_param(token, "token_type"),
+        expires_in: token_param(token, "expires_in")
       )
     end
 
     # String keys for session storage and documented public API responses.
     def for_session(raw)
+      public_tokens(raw).transform_keys(&:to_s)
+    end
+
+    # Full oauth2 hash with string keys for refresh_token responses.
+    def for_refresh_response(raw)
       normalize(raw).transform_keys(&:to_s)
     end
 

--- a/lib/kinde_sdk/token_hash.rb
+++ b/lib/kinde_sdk/token_hash.rb
@@ -1,0 +1,50 @@
+module KindeSdk
+  # Normalizes token hashes so the SDK does not depend on oauth2's #to_hash key format.
+  # Accepts string or symbol keys on input; internal storage uses symbol keys.
+  module TokenHash
+    KEYS = %i[access_token refresh_token expires_at id_token scope token_type expires_in].freeze
+
+    module_function
+
+    def normalize(raw)
+      return {} if raw.nil?
+      return {} if raw.respond_to?(:empty?) && raw.empty?
+
+      raw.each_with_object({}) do |(key, value), memo|
+        sym_key = key.to_sym
+        next unless KEYS.include?(sym_key)
+
+        memo[sym_key] = value
+      end.tap do |hash|
+        hash[:access_token] = hash[:access_token].to_s if hash[:access_token]
+      end
+    end
+
+    def access_token(raw)
+      normalize(raw)[:access_token]
+    end
+
+    def from_access_token(token)
+      normalize(
+        {
+          access_token: token.token,
+          refresh_token: token.refresh_token,
+          expires_at: token.expires_at,
+          id_token: token_param(token, "id_token"),
+          scope: token_param(token, "scope"),
+          token_type: token_param(token, "token_type"),
+          expires_in: token_param(token, "expires_in")
+        }.compact
+      )
+    end
+
+    # String keys for session storage and documented public API responses.
+    def for_session(raw)
+      normalize(raw).transform_keys(&:to_s)
+    end
+
+    def token_param(token, key)
+      token.params[key] || token.params[key.to_sym]
+    end
+  end
+end

--- a/lib/kinde_sdk/token_manager.rb
+++ b/lib/kinde_sdk/token_manager.rb
@@ -9,7 +9,7 @@ module KindeSdk
     end
 
     def set_tokens(tokens)
-      @tokens = tokens.transform_keys(&:to_sym).freeze
+      @tokens = TokenHash.normalize(tokens).freeze
       @bearer_token = @tokens[:access_token]
       @expires_at = @tokens[:expires_at]
       @tokens

--- a/lib/kinde_sdk/token_store.rb
+++ b/lib/kinde_sdk/token_store.rb
@@ -7,7 +7,7 @@ module KindeSdk
     end
 
     def set_tokens(tokens)
-      @tokens = (tokens || {}).transform_keys(&:to_sym)
+      @tokens = TokenHash.normalize(tokens)
       @bearer_token = @tokens[:access_token]
       @expires_at = @tokens[:expires_at]
       @tokens

--- a/spec/kinde_sdk_spec.rb
+++ b/spec/kinde_sdk_spec.rb
@@ -190,6 +190,38 @@ RSpec.describe KindeSdk do
     end
   end
 
+  describe "#refresh_token" do
+    it "returns string-keyed tokens without relying on oauth2 #to_hash" do
+      refreshed = double(
+        "OAuth2::AccessToken",
+        token: token,
+        refresh_token: refresh_token,
+        expires_at: Time.now.to_i + 7200,
+        params: {}
+      )
+      allow(refreshed).to receive(:to_hash).and_return(
+        access_token: "must-not-be-used",
+        refresh_token: refresh_token,
+        expires_at: Time.now.to_i + 7200
+      )
+
+      access_token_object = double(refresh: refreshed)
+      allow(OAuth2::AccessToken).to receive(:from_hash).and_return(access_token_object)
+
+      stored_tokens = {
+        access_token: token,
+        refresh_token: refresh_token,
+        expires_at: Time.now.to_i + 3600
+      }
+
+      result = described_class.refresh_token(stored_tokens)
+
+      expect(result["access_token"]).to eq(token)
+      expect(result["refresh_token"]).to eq(refresh_token)
+      expect(result[:access_token]).to be_nil
+    end
+  end
+
   describe "client" do
     let(:hash_to_encode) do
       { "aud" => [],
@@ -212,6 +244,24 @@ RSpec.describe KindeSdk do
     let(:expires_at) { Time.now.to_i + 10000000 }
     let(:tokens_hash) { { access_token: token, expires_at: expires_at, refresh_token: refresh_token } }
     let(:client) { described_class.client(tokens_hash, auto_refresh_tokens) }
+
+    context "with string-key session tokens" do
+      it "accepts string keys" do
+        session_tokens = {
+          "access_token" => token,
+          "refresh_token" => refresh_token,
+          "expires_at" => expires_at
+        }
+
+        expect(described_class.client(session_tokens, false).bearer_token).to eq(token)
+      end
+
+      it "raises when access_token is missing" do
+        expect {
+          described_class.client({ "refresh_token" => refresh_token }, false)
+        }.to raise_error(KindeSdk::AuthenticationError, /Missing access_token/)
+      end
+    end
 
     context "with session integration" do
       before do
@@ -447,4 +497,83 @@ RSpec.describe KindeSdk do
   end
 end
 
+RSpec.describe KindeSdk::TokenHash do
+  describe ".normalize" do
+    it "accepts string keys" do
+      hash = described_class.normalize(
+        "access_token" => "abc",
+        "refresh_token" => "def",
+        "expires_at" => 123
+      )
+
+      expect(hash).to eq(
+        access_token: "abc",
+        refresh_token: "def",
+        expires_at: 123
+      )
+    end
+
+    it "accepts symbol keys" do
+      hash = described_class.normalize(
+        access_token: "abc",
+        refresh_token: "def",
+        expires_at: 123
+      )
+
+      expect(hash[:access_token]).to eq("abc")
+    end
+
+    it "returns an empty hash for nil" do
+      expect(described_class.normalize(nil)).to eq({})
+    end
+
+    it "ignores unknown keys" do
+      hash = described_class.normalize(access_token: "abc", mode: :header)
+      expect(hash).to eq(access_token: "abc")
+    end
+  end
+
+  describe ".from_access_token" do
+    let(:oauth_token) do
+      double(
+        "OAuth2::AccessToken",
+        token: "access-token-value",
+        refresh_token: "refresh-token-value",
+        expires_at: 1_700_000_000,
+        params: {
+          "id_token" => "id-token",
+          "scope" => "openid profile",
+          "token_type" => "bearer"
+        }
+      )
+    end
+
+    it "builds a normalized hash without calling oauth2 #to_hash" do
+      expect(oauth_token).not_to receive(:to_hash)
+
+      hash = described_class.from_access_token(oauth_token)
+
+      expect(hash).to eq(
+        access_token: "access-token-value",
+        refresh_token: "refresh-token-value",
+        expires_at: 1_700_000_000,
+        id_token: "id-token",
+        scope: "openid profile",
+        token_type: "bearer"
+      )
+    end
+  end
+
+  describe ".for_session" do
+    it "returns string keys for documented session/API compatibility" do
+      session_hash = described_class.for_session(access_token: "abc", expires_at: 123)
+
+      expect(session_hash).to eq(
+        "access_token" => "abc",
+        "expires_at" => 123
+      )
+      expect(session_hash["access_token"]).to eq("abc")
+    end
+  end
+end
 

--- a/spec/kinde_sdk_spec.rb
+++ b/spec/kinde_sdk_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe KindeSdk do
   end
 
   describe "#refresh_token" do
-    it "returns string-keyed tokens without relying on oauth2 #to_hash" do
+    it "returns string-keyed tokens with the full oauth2 hash contract" do
       refreshed = double(
         "OAuth2::AccessToken",
         token: token,
@@ -200,24 +200,37 @@ RSpec.describe KindeSdk do
         params: {}
       )
       allow(refreshed).to receive(:to_hash).and_return(
-        access_token: "must-not-be-used",
+        access_token: token,
         refresh_token: refresh_token,
-        expires_at: Time.now.to_i + 7200
+        expires_at: Time.now.to_i + 7200,
+        mode: :header,
+        header_format: "Bearer %s"
       )
 
       access_token_object = double(refresh: refreshed)
       allow(OAuth2::AccessToken).to receive(:from_hash).and_return(access_token_object)
 
       stored_tokens = {
-        access_token: token,
-        refresh_token: refresh_token,
-        expires_at: Time.now.to_i + 3600
+        "access_token" => token,
+        "refresh_token" => refresh_token,
+        "expires_at" => Time.now.to_i + 3600,
+        "mode" => :query,
+        "param_name" => "access_token"
       }
+
+      expect(OAuth2::AccessToken).to receive(:from_hash) do |_client, normalized|
+        expect(normalized[:access_token]).to eq(token)
+        expect(normalized[:mode]).to eq(:query)
+        expect(normalized[:param_name]).to eq("access_token")
+        access_token_object
+      end
 
       result = described_class.refresh_token(stored_tokens)
 
       expect(result["access_token"]).to eq(token)
       expect(result["refresh_token"]).to eq(refresh_token)
+      expect(result["mode"]).to eq(:header)
+      expect(result["header_format"]).to eq("Bearer %s")
       expect(result[:access_token]).to be_nil
     end
   end
@@ -527,9 +540,42 @@ RSpec.describe KindeSdk::TokenHash do
       expect(described_class.normalize(nil)).to eq({})
     end
 
-    it "ignores unknown keys" do
-      hash = described_class.normalize(access_token: "abc", mode: :header)
-      expect(hash).to eq(access_token: "abc")
+    it "preserves oauth2 reconstruction fields" do
+      hash = described_class.normalize(
+        "access_token" => "abc",
+        "mode" => :header,
+        header_format: "Bearer %s",
+        "token_name" => :access_token,
+        "expires_latency" => 5,
+        "expires" => 3600
+      )
+
+      expect(hash).to eq(
+        access_token: "abc",
+        mode: :header,
+        header_format: "Bearer %s",
+        token_name: :access_token,
+        expires_latency: 5,
+        expires: 3600
+      )
+    end
+  end
+
+  describe ".public_tokens" do
+    it "returns only the documented public SDK token fields" do
+      hash = described_class.public_tokens(
+        access_token: "abc",
+        refresh_token: "def",
+        expires_at: 123,
+        mode: :header,
+        header_format: "Bearer %s"
+      )
+
+      expect(hash).to eq(
+        access_token: "abc",
+        refresh_token: "def",
+        expires_at: 123
+      )
     end
   end
 
@@ -560,6 +606,26 @@ RSpec.describe KindeSdk::TokenHash do
         id_token: "id-token",
         scope: "openid profile",
         token_type: "bearer"
+      )
+    end
+  end
+
+  describe ".for_refresh_response" do
+    it "returns string keys while preserving the full oauth2 hash contract" do
+      response = described_class.for_refresh_response(
+        access_token: "abc",
+        refresh_token: "def",
+        expires_at: 123,
+        mode: :header,
+        param_name: "access_token"
+      )
+
+      expect(response).to eq(
+        "access_token" => "abc",
+        "refresh_token" => "def",
+        "expires_at" => 123,
+        "mode" => :header,
+        "param_name" => "access_token"
       )
     end
   end


### PR DESCRIPTION
# Fix oauth2 2.0.10+ token hash incompatibility

Normalize token hashes at the SDK boundary so login and refresh keep working when oauth2 stops returning string-keyed `#to_hash` output.

# Explain your changes

Upgrading `kinde_sdk` could silently pull in `oauth2` 2.0.10+ via Bundler. In those versions, `OAuth2::AccessToken#to_hash` returns a plain symbol-keyed hash instead of an indifferent-access hash, so lookups like `tokens_hash["access_token"]` return `nil`. That led to API clients being built without a bearer token and login failing with 401 on profile fetch.

This PR adds a `KindeSdk::TokenHash` normalization layer and routes all public token entry points through it:

- **`fetch_tokens`** — builds tokens from `OAuth2::AccessToken` attributes via `TokenHash.from_access_token`, not `#to_hash`
- **`refresh_token`** — returns a string-keyed hash via `TokenHash.for_session` (matches documented API shape)
- **`client`** — normalizes input (accepts string or symbol keys) and raises `AuthenticationError` when `access_token` is missing
- **`token_expired?`**, **`TokenStore`**, **`TokenManager`** — normalize tokens before use

Tests were added to `spec/kinde_sdk_spec.rb` covering string-key session tokens, refresh without relying on `#to_hash`, and `TokenHash` normalization behavior.

Customers on `oauth2` 2.0.10+ should no longer need to pin `oauth2` to 2.0.9 after upgrading to this SDK version.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._